### PR TITLE
docs: redocument with roxygen2 8.0.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ LazyData: true
 LazyDataCompression: xz
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+Config/roxygen2/version: 8.0.0.9000

--- a/man/mlr3data-package.Rd
+++ b/man/mlr3data-package.Rd
@@ -19,6 +19,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Marc Becker \email{marcbecker@posteo.de} (\href{https://orcid.org/0000-0002-8115-0400}{ORCID})
 
+Authors:
+\itemize{
+  \item Marc Becker \email{marcbecker@posteo.de} (\href{https://orcid.org/0000-0002-8115-0400}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Michel Lang \email{michellang@gmail.com} (\href{https://orcid.org/0000-0001-9754-0393}{ORCID}) [contributor]


### PR DESCRIPTION
Regenerate man pages and NAMESPACE with `devtools::document()` using roxygen2 8.0.0.9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)